### PR TITLE
Add unit test suite, refactor for testability, fix 3 latent bugs

### DIFF
--- a/IRIPCamera-swift/Device/AddressConnector.swift
+++ b/IRIPCamera-swift/Device/AddressConnector.swift
@@ -61,7 +61,7 @@ class AddressConnector: HttpAPICommander, HttpRequestDelegate {
             return
         }
 
-        HttpRequest.shared.doJsonRequest(
+        httpRequest.doJsonRequest(
             token: token,
             url: "",
             method: .get,
@@ -76,7 +76,7 @@ class AddressConnector: HttpAPICommander, HttpRequestDelegate {
             return
         }
 
-        HttpRequest.shared.doJsonRequest(
+        httpRequest.doJsonRequest(
             token: token,
             url: "",
             method: .get,

--- a/IRIPCamera-swift/Device/HttpAPICommander.swift
+++ b/IRIPCamera-swift/Device/HttpAPICommander.swift
@@ -109,6 +109,9 @@ class HttpAPICommander {
     var currentErrorType: ConnectorErrorType = .authorizationError
     var isAppAndDutUnderTheSameLAN: Bool = false
 
+    /// Injectable HTTP client; defaults to the shared instance but can be replaced in tests.
+    var httpRequest: HttpRequesting = HttpRequest.shared
+
     // MARK: - Initializer
     init(address: String, port: MultiPort, user: String, password: String, scheme: String) {
         self.commandPort = MultiPort.initial()

--- a/IRIPCamera-swift/Device/StaticHttpRequest.swift
+++ b/IRIPCamera-swift/Device/StaticHttpRequest.swift
@@ -18,7 +18,31 @@ extension HttpRequestDelegate {
     func updateProgress(totalBytesRead: Int64, totalBytesExpectedToRead: Int64) { }
 }
 
-class HttpRequest {
+/// HTTP verb expressed without leaking Alamofire's type to callers/tests.
+enum HttpRequestMethod {
+    case get
+    case post
+
+    var alamofireMethod: HTTPMethod {
+        switch self {
+        case .get: return .get
+        case .post: return .post
+        }
+    }
+}
+
+/// Abstraction over `HttpRequest` so collaborators can be unit tested with a mock.
+protocol HttpRequesting: AnyObject {
+    func doJsonRequest(
+        token: String?,
+        url: String,
+        method: HttpRequestMethod,
+        callbackID: DeviceConnectorCommandStatus,
+        target: HttpRequestDelegate
+    )
+}
+
+class HttpRequest: HttpRequesting {
 
     // MARK: - Properties
     static let shared = HttpRequest()
@@ -46,7 +70,7 @@ class HttpRequest {
     func doJsonRequest(
         token: String?,
         url: String,
-        method: HTTPMethod,
+        method: HttpRequestMethod,
         callbackID: DeviceConnectorCommandStatus,
         target: HttpRequestDelegate
     ) {
@@ -69,12 +93,13 @@ class HttpRequest {
     private func doJsonHttpRequest(
         token: String?,
         url: URL,
-        method: HTTPMethod,
+        method: HttpRequestMethod,
         callbackID: DeviceConnectorCommandStatus,
         scheme: String,
         target: HttpRequestDelegate
     ) {
-        let request = URLRequest(url: changeURL(url: url, withScheme: scheme))
+        var request = URLRequest(url: changeURL(url: url, withScheme: scheme))
+        request.httpMethod = method.alamofireMethod.rawValue
 
         AF.request(request)
             .validate()

--- a/IRIPCamera-swift/Device/StaticHttpRequest.swift
+++ b/IRIPCamera-swift/Device/StaticHttpRequest.swift
@@ -50,7 +50,9 @@ class HttpRequest: HttpRequesting {
     private var manager: Session
     private var requestQueue: OperationQueue
 
-    private init() {
+    // Internal (not private) so tests can exercise an isolated instance instead
+    // of mutating the shared singleton.
+    init() {
         self.manager = Session()
         self.requestQueue = OperationQueue()
     }

--- a/IRIPCamera-swift/Stream/IRCustomStreamConnector.swift
+++ b/IRIPCamera-swift/Stream/IRCustomStreamConnector.swift
@@ -83,7 +83,9 @@ extension IRCustomStreamConnector: DeviceConnectorDelegate {
                              url: String,
                              ipRatio: Int) {
         if resultCode == 0 {
-            deviceInfo?.streamInfo = streamInfoArray[ch]
+            if streamInfoArray.indices.contains(ch) {
+                deviceInfo?.streamInfo = streamInfoArray[ch]
+            }
             response?.rtspURL = url
             delegate?.startStreaming(with: response)
         }

--- a/IRIPCamera-swift/Stream/IRStreamConnectionRequestFactory.swift
+++ b/IRIPCamera-swift/Stream/IRStreamConnectionRequestFactory.swift
@@ -9,37 +9,32 @@ import Foundation
 
 class IRStreamConnectionRequestFactory {
 
-    static func createStreamConnectionRequest() -> [IRStreamConnectionRequest] {
-        var devices: [IRStreamConnectionRequest] = []
-        let userDefaults = UserDefaults.standard
+    /// Pairs of (RTSP URL key, matching enable-flag key) in display order.
+    private static let urlEntries: [(urlKey: String, enableKey: String)] = [
+        (RTSP_URL_KEY, RTSP_URL_ENABLE_KEY_1),
+        (RTSP_URL_KEY_2, RTSP_URL_ENABLE_KEY_2),
+        (RTSP_URL_KEY_3, RTSP_URL_ENABLE_KEY_3),
+        (RTSP_URL_KEY_4, RTSP_URL_ENABLE_KEY_4)
+    ]
 
-        if userDefaults.bool(forKey: ENABLE_RTSP_URL_KEY) {
-            let urls = [
-                userDefaults.string(forKey: RTSP_URL_KEY) ?? "",
-                userDefaults.string(forKey: RTSP_URL_KEY_2) ?? "",
-                userDefaults.string(forKey: RTSP_URL_KEY_3) ?? "",
-                userDefaults.string(forKey: RTSP_URL_KEY_4) ?? ""
-            ]
-            let enables = [
-                userDefaults.object(forKey: RTSP_URL_ENABLE_KEY_1) as? Bool ?? true,
-                userDefaults.object(forKey: RTSP_URL_ENABLE_KEY_2) as? Bool ?? true,
-                userDefaults.object(forKey: RTSP_URL_ENABLE_KEY_3) as? Bool ?? true,
-                userDefaults.object(forKey: RTSP_URL_ENABLE_KEY_4) as? Bool ?? true
-            ]
-            for (index, url) in urls.enumerated() {
-                guard index < enables.count, enables[index] else { continue }
-                let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { continue }
-                let request = IRStreamConnectionRequest()
-                request.rtspUrl = trimmed
-                devices.append(request)
-            }
-        } else {
-            let device = DeviceClass()
-            let request = IRCustomStreamConnectionRequest(device: device)
-            devices.append(request)
+    static func createStreamConnectionRequest(
+        userDefaults: UserDefaults = .standard
+    ) -> [IRStreamConnectionRequest] {
+        guard userDefaults.bool(forKey: ENABLE_RTSP_URL_KEY) else {
+            return [IRCustomStreamConnectionRequest(device: DeviceClass())]
         }
 
-        return devices
+        return urlEntries.compactMap { entry in
+            let enabled = userDefaults.object(forKey: entry.enableKey) as? Bool ?? true
+            guard enabled else { return nil }
+
+            let trimmed = (userDefaults.string(forKey: entry.urlKey) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+
+            let request = IRStreamConnectionRequest()
+            request.rtspUrl = trimmed
+            return request
+        }
     }
 }

--- a/IRIPCamera-swift/Stream/IRStreamController.swift
+++ b/IRIPCamera-swift/Stream/IRStreamController.swift
@@ -19,6 +19,26 @@ enum IRStreamControllerStatus: Int {
     case failed
 }
 
+/// Playback states the controller reacts to, decoupled from IRPlayer's `IRPlayerState`
+/// so the state machine can be exercised without an IRPlayer dependency.
+enum PlaybackState {
+    case buffering
+    case readyToPlay
+    case playing
+    case failed
+    case other
+
+    init(_ irState: IRPlayerState) {
+        switch irState {
+        case .buffering: self = .buffering
+        case .readyToPlay: self = .readyToPlay
+        case .playing: self = .playing
+        case .failed: self = .failed
+        default: self = .other
+        }
+    }
+}
+
 protocol IRStreamControllerDelegate: AnyObject {
     func connectResult(_ videoView: Any, connection: Bool, micSupport: Bool, speakerSupport: Bool)
     func showErrorMessage(_ msg: String)
@@ -73,6 +93,7 @@ class IRStreamController: NSObject {
     convenience init(device: DeviceClass) {
         self.init()
         streamConnector = IRCustomStreamConnector()
+        streamConnector?.delegate = self
         if let customStreamConnector = streamConnector as? IRCustomStreamConnector {
             customStreamConnector.deviceInfo = device
         }
@@ -156,20 +177,23 @@ class IRStreamController: NSObject {
     // MARK: - Notification Handlers
     @objc func stateAction(_ notification: Notification) {
         guard let userInfo = notification.userInfo else { return }
-
         let state = IRState.state(fromUserInfo: userInfo)
-        switch state.current {
+        handle(playbackState: PlaybackState(state.current))
+    }
+
+    /// Reacts to a playback state transition. Extracted from `stateAction` so the
+    /// state machine can be unit tested without constructing IRPlayer notifications.
+    func handle(playbackState state: PlaybackState) {
+        switch state {
         case .buffering:
             eventDelegate?.streamControllerStatusChanged(.buffering)
-            break
         case .readyToPlay:
             connectSuccess()
         case .playing:
             eventDelegate?.streamControllerStatusChanged(.playing)
         case .failed:
             reconnectToDevice()
-            break
-        default:
+        case .other:
             break
         }
     }

--- a/IRIPCamera-swift/Stream/IRStreamControllerFactory.swift
+++ b/IRIPCamera-swift/Stream/IRStreamControllerFactory.swift
@@ -10,14 +10,9 @@ import Foundation
 class IRStreamControllerFactory {
 
     static func createStreamController(by request: IRStreamConnectionRequest) -> IRStreamController {
-        var streamController: IRStreamController?
-
         if let customRequest = request as? IRCustomStreamConnectionRequest {
-            streamController = IRStreamController(device: customRequest.device)
-        } else {
-            streamController = IRStreamController(rtspURL: request.rtspUrl)
+            return IRStreamController(device: customRequest.device)
         }
-
-        return streamController!
+        return IRStreamController(rtspURL: request.rtspUrl)
     }
 }

--- a/IRIPCamera-swift/Stream/IRStreamVideoDecoder.swift
+++ b/IRIPCamera-swift/Stream/IRStreamVideoDecoder.swift
@@ -23,9 +23,6 @@ class FrameContext {
 final class IRStreamVideoDecoder: IRFFVideoInput {
 
     // MARK: - Properties
-    private let startCode3: [UInt8] = [0x00, 0x00, 0x01]
-    private let startCode4: [UInt8] = [0x00, 0x00, 0x00, 0x01]
-
     private var session: VTDecompressionSession?
     private var videoFormatDescr: CMFormatDescription?
     private var status: OSStatus = noErr
@@ -278,23 +275,23 @@ extension IRStreamVideoDecoder {
 
         let size = Int(pCodecCtx.pointee.extradata_size)
         let firstByte = extradata[0]
+        let bytes = [UInt8](UnsafeBufferPointer(start: extradata, count: size))
 
         if codecKind == .h264 {
             if firstByte == 0x01 {
                 inputFormat = .avccOrHvcc
-                _ = parseAVCC(extradata: extradata, size: size)
-            } else if isAnnexBStartCode(extradata, size: size) {
+                applyH264(NALUParser.parseAVCC(bytes))
+            } else if NALUParser.isAnnexBStartCode(bytes) {
                 inputFormat = .annexB
-                parseAnnexBParameterSets(extradata: extradata, size: size, isHEVC: false)
+                applyH264(NALUParser.parseAnnexBParameterSets(bytes, isHEVC: false))
                 nalLengthSize = 4
+            } else if let sets = NALUParser.parseAVCC(bytes) {
+                inputFormat = .avccOrHvcc
+                applyH264(sets)
             } else {
-                if !parseAVCC(extradata: extradata, size: size) {
-                    inputFormat = .annexB
-                    parseAnnexBParameterSets(extradata: extradata, size: size, isHEVC: false)
-                    nalLengthSize = 4
-                } else {
-                    inputFormat = .avccOrHvcc
-                }
+                inputFormat = .annexB
+                applyH264(NALUParser.parseAnnexBParameterSets(bytes, isHEVC: false))
+                nalLengthSize = 4
             }
 
             guard let firstSPS = spsList.first, let firstPPS = ppsList.first else {
@@ -337,19 +334,18 @@ extension IRStreamVideoDecoder {
         } else {
             if firstByte == 0x01 {
                 inputFormat = .avccOrHvcc
-                _ = parseHVCC(extradata: extradata, size: size)
-            } else if isAnnexBStartCode(extradata, size: size) {
+                applyHEVC(NALUParser.parseHVCC(bytes))
+            } else if NALUParser.isAnnexBStartCode(bytes) {
                 inputFormat = .annexB
-                parseAnnexBParameterSets(extradata: extradata, size: size, isHEVC: true)
+                applyHEVC(NALUParser.parseAnnexBParameterSets(bytes, isHEVC: true))
                 nalLengthSize = 4
+            } else if let sets = NALUParser.parseHVCC(bytes) {
+                inputFormat = .avccOrHvcc
+                applyHEVC(sets)
             } else {
-                if !parseHVCC(extradata: extradata, size: size) {
-                    inputFormat = .annexB
-                    parseAnnexBParameterSets(extradata: extradata, size: size, isHEVC: true)
-                    nalLengthSize = 4
-                } else {
-                    inputFormat = .avccOrHvcc
-                }
+                inputFormat = .annexB
+                applyHEVC(NALUParser.parseAnnexBParameterSets(bytes, isHEVC: true))
+                nalLengthSize = 4
             }
 
             guard let firstVPS = vpsList.first, let firstSPS = spsList.first, let firstPPS = ppsList.first else {
@@ -400,128 +396,21 @@ extension IRStreamVideoDecoder {
         }
     }
 
-    @discardableResult
-    private func parseAVCC(extradata: UnsafeMutablePointer<UInt8>, size: Int) -> Bool {
-        guard size >= 7, extradata[0] == 1 else { return false }
-        let lengthSizeMinusOne = Int(extradata[4] & 0x03)
-        nalLengthSize = lengthSizeMinusOne + 1
-        var offset = 5
-
-        let numOfSPS = Int(extradata[offset] & 0x1F)
-        offset += 1
-
-        spsList.removeAll()
-        ppsList.removeAll()
-
-        for _ in 0..<numOfSPS {
-            if offset + 2 > size { return false }
-            let spsLength = Int(extradata[offset]) << 8 | Int(extradata[offset + 1])
-            offset += 2
-            if offset + spsLength > size { return false }
-            let sps = Data(bytes: extradata.advanced(by: offset), count: spsLength)
-            spsList.append(sps)
-            offset += spsLength
-        }
-
-        if offset + 1 > size { return false }
-        let numOfPPS = Int(extradata[offset])
-        offset += 1
-
-        for _ in 0..<numOfPPS {
-            if offset + 2 > size { return false }
-            let ppsLength = Int(extradata[offset]) << 8 | Int(extradata[offset + 1])
-            offset += 2
-            if offset + ppsLength > size { return false }
-            let pps = Data(bytes: extradata.advanced(by: offset), count: ppsLength)
-            ppsList.append(pps)
-            offset += ppsLength
-        }
-
-        return !spsList.isEmpty && !ppsList.isEmpty
+    /// Applies parsed H.264 parameter sets to instance state.
+    private func applyH264(_ sets: NALUParser.ParameterSets?) {
+        guard let sets else { return }
+        spsList = sets.sps
+        ppsList = sets.pps
+        nalLengthSize = sets.nalLengthSize
     }
 
-    @discardableResult
-    private func parseHVCC(extradata: UnsafeMutablePointer<UInt8>, size: Int) -> Bool {
-        guard size >= 23, extradata[0] == 1 else { return false }
-
-        let lengthSizeMinusOne = Int(extradata[21] & 0x03)
-        nalLengthSize = lengthSizeMinusOne + 1
-
-        var offset = 22
-        if offset >= size { return false }
-
-        let numOfArrays = Int(extradata[offset])
-        offset += 1
-
-        spsList.removeAll()
-        ppsList.removeAll()
-        vpsList.removeAll()
-
-        for _ in 0..<numOfArrays {
-            if offset + 3 > size { return false }
-            let arrayCompletenessAndType = extradata[offset]
-            offset += 1
-            let nalUnitType = Int(arrayCompletenessAndType & 0x3F)
-            let numNalus = Int(extradata[offset]) << 8 | Int(extradata[offset + 1])
-            offset += 2
-
-            for _ in 0..<numNalus {
-                if offset + 2 > size { return false }
-                let nalUnitLength = Int(extradata[offset]) << 8 | Int(extradata[offset + 1])
-                offset += 2
-                if offset + nalUnitLength > size { return false }
-                let data = Data(bytes: extradata.advanced(by: offset), count: nalUnitLength)
-                switch nalUnitType {
-                case 32: vpsList.append(data)
-                case 33: spsList.append(data)
-                case 34: ppsList.append(data)
-                default: break
-                }
-                offset += nalUnitLength
-            }
-        }
-
-        return !vpsList.isEmpty && !spsList.isEmpty && !ppsList.isEmpty
-    }
-
-    private func parseAnnexBParameterSets(extradata: UnsafeMutablePointer<UInt8>, size: Int, isHEVC: Bool) {
-        spsList.removeAll()
-        ppsList.removeAll()
-        vpsList.removeAll()
-
-        var index = 0
-        while let (range, naluType) = nextAnnexBNAL(in: extradata, size: size, start: index, isHEVC: isHEVC) {
-            if isHEVC {
-                switch naluType {
-                case 32:
-                    let vps = Data(bytes: extradata.advanced(by: range.lowerBound), count: range.count)
-                    vpsList.append(vps)
-                case 33:
-                    let sps = Data(bytes: extradata.advanced(by: range.lowerBound), count: range.count)
-                    spsList.append(sps)
-                case 34:
-                    let pps = Data(bytes: extradata.advanced(by: range.lowerBound), count: range.count)
-                    ppsList.append(pps)
-                default:
-                    break
-                }
-            } else {
-                if naluType == 7 {
-                    let sps = Data(bytes: extradata.advanced(by: range.lowerBound), count: range.count)
-                    spsList.append(sps)
-                } else if naluType == 8 {
-                    let pps = Data(bytes: extradata.advanced(by: range.lowerBound), count: range.count)
-                    ppsList.append(pps)
-                }
-            }
-            index = range.upperBound
-        }
-    }
-
-    private func isAnnexBStartCode(_ ptr: UnsafeMutablePointer<UInt8>, size: Int) -> Bool {
-        if size >= 4 && memcmp(ptr, startCode4, 4) == 0 { return true }
-        if size >= 3 && memcmp(ptr, startCode3, 3) == 0 { return true }
-        return false
+    /// Applies parsed HEVC parameter sets to instance state.
+    private func applyHEVC(_ sets: NALUParser.ParameterSets?) {
+        guard let sets else { return }
+        vpsList = sets.vps
+        spsList = sets.sps
+        ppsList = sets.pps
+        nalLengthSize = sets.nalLengthSize
     }
 }
 
@@ -532,119 +421,15 @@ extension IRStreamVideoDecoder {
     private func buildAVCCSample(from packet: AVPacket) -> (Data?, Int) {
         guard let dataPtr = packet.data, packet.size > 0 else { return (nil, 0) }
         let length = Int(packet.size)
+        let bytes = [UInt8](UnsafeBufferPointer(start: dataPtr, count: length))
 
-        let looksLikeAnnexB = looksLikeAnnexBBuffer(dataPtr, length: length)
-        if looksLikeAnnexB {
-            let converted = convertAnnexBToAVCC(dataPtr, length: length, nalLengthSize: nalLengthSize)
+        if NALUParser.looksLikeAnnexB(bytes) {
+            let converted = NALUParser.convertAnnexBToAVCC(bytes, nalLengthSize: nalLengthSize)
             return (converted, converted.count)
         } else {
             // Wrap as Data directly; it will be copied into CMBlockBuffer later
-            let data = Data(bytes: dataPtr, count: length)
-            return (data, length)
+            return (Data(bytes), length)
         }
-    }
-
-    private func looksLikeAnnexBBuffer(_ ptr: UnsafeMutablePointer<UInt8>, length: Int) -> Bool {
-        if length >= 4 && memcmp(ptr, startCode4, 4) == 0 { return true }
-        if length >= 3 && memcmp(ptr, startCode3, 3) == 0 { return true }
-        var i = 0
-        while i + 4 <= length {
-            if memcmp(ptr.advanced(by: i), startCode4, 4) == 0 { return true }
-            if i + 3 <= length && memcmp(ptr.advanced(by: i), startCode3, 3) == 0 { return true }
-            i += 1
-        }
-        return false
-    }
-
-    // Convert to Data (length-prefixed)
-    private func convertAnnexBToAVCC(_ ptr: UnsafeMutablePointer<UInt8>, length: Int, nalLengthSize: Int) -> Data {
-        var nalRanges: [(start: Int, end: Int)] = []
-        var i = 0
-        func matchStartCode(_ p: UnsafeMutablePointer<UInt8>, _ len: Int) -> Int? {
-            if len >= 4 && memcmp(p, startCode4, 4) == 0 { return 4 }
-            if len >= 3 && memcmp(p, startCode3, 3) == 0 { return 3 }
-            return nil
-        }
-
-        while i < length {
-            guard let scLen = matchStartCode(ptr.advanced(by: i), length - i) else {
-                i += 1
-                continue
-            }
-            let naluStart = i + scLen
-            var j = naluStart
-            var nextStart: Int?
-            while j < length {
-                if let _ = matchStartCode(ptr.advanced(by: j), length - j) {
-                    nextStart = j
-                    break
-                }
-                j += 1
-            }
-            let naluEnd = nextStart ?? length
-            if naluEnd > naluStart {
-                nalRanges.append((start: naluStart, end: naluEnd))
-            }
-            i = naluEnd
-        }
-
-        if nalRanges.isEmpty { return Data() }
-
-        var out = Data()
-        out.reserveCapacity(nalRanges.reduce(0) { $0 + nalLengthSize + ($1.end - $1.start) })
-
-        for r in nalRanges {
-            let nalSize = r.end - r.start
-            // Write length (big-endian)
-            for b in stride(from: (nalLengthSize - 1), through: 0, by: -1) {
-                let v = UInt8((nalSize >> (b * 8)) & 0xFF)
-                out.append(v)
-            }
-            // Write NALU payload
-            out.append(UnsafeBufferPointer(start: ptr.advanced(by: r.start), count: nalSize))
-        }
-        return out
-    }
-
-    private func nextAnnexBNAL(in ptr: UnsafeMutablePointer<UInt8>, size: Int, start: Int, isHEVC: Bool) -> ((Range<Int>, Int))? {
-        var i = start
-        func matchStartCode(_ p: UnsafeMutablePointer<UInt8>, _ len: Int) -> Int? {
-            if len >= 4 && memcmp(p, startCode4, 4) == 0 { return 4 }
-            if len >= 3 && memcmp(p, startCode3, 3) == 0 { return 3 }
-            return nil
-        }
-
-        var scLen1: Int?
-        while i < size {
-            if let sc = matchStartCode(ptr.advanced(by: i), size - i) {
-                scLen1 = sc
-                break
-            }
-            i += 1
-        }
-        guard let sc1 = scLen1 else { return nil }
-        let naluStart = i + sc1
-
-        var j = naluStart
-        var nextStartIdx: Int?
-        while j < size {
-            if let _ = matchStartCode(ptr.advanced(by: j), size - j) {
-                nextStartIdx = j
-                break
-            }
-            j += 1
-        }
-        let naluEnd = nextStartIdx ?? size
-        guard naluEnd > naluStart else { return nil }
-
-        let firstByte = ptr[naluStart]
-        let naluType: Int
-        if isHEVC {
-            naluType = Int((firstByte >> 1) & 0x3F)
-        } else {
-            naluType = Int(firstByte & 0x1F)
-        }
-        return (naluStart..<naluEnd, naluType)
     }
 }
 

--- a/IRIPCamera-swift/Stream/IRStreamVideoDecoder.swift
+++ b/IRIPCamera-swift/Stream/IRStreamVideoDecoder.swift
@@ -421,14 +421,15 @@ extension IRStreamVideoDecoder {
     private func buildAVCCSample(from packet: AVPacket) -> (Data?, Int) {
         guard let dataPtr = packet.data, packet.size > 0 else { return (nil, 0) }
         let length = Int(packet.size)
-        let bytes = [UInt8](UnsafeBufferPointer(start: dataPtr, count: length))
+        // Parse over the FFmpeg buffer in place; copy once into Data only at the end.
+        let buffer = UnsafeBufferPointer(start: dataPtr, count: length)
 
-        if NALUParser.looksLikeAnnexB(bytes) {
-            let converted = NALUParser.convertAnnexBToAVCC(bytes, nalLengthSize: nalLengthSize)
+        if NALUParser.looksLikeAnnexB(buffer) {
+            let converted = NALUParser.convertAnnexBToAVCC(buffer, nalLengthSize: nalLengthSize)
             return (converted, converted.count)
         } else {
             // Wrap as Data directly; it will be copied into CMBlockBuffer later
-            return (Data(bytes), length)
+            return (Data(buffer: buffer), length)
         }
     }
 }

--- a/IRIPCamera-swift/Stream/NALUParser.swift
+++ b/IRIPCamera-swift/Stream/NALUParser.swift
@@ -1,0 +1,254 @@
+//
+//  NALUParser.swift
+//  IRIPCamera-swift
+//
+//  Pure, dependency-free helpers for parsing H.264/HEVC parameter sets and
+//  converting Annex B byte streams to length-prefixed (AVCC/HVCC) samples.
+//
+//  These were extracted from `IRStreamVideoDecoder` so the bit-twiddling logic
+//  can be unit tested on plain `[UInt8]` / `Data` without VideoToolbox, FFmpeg
+//  or unsafe pointers.
+//
+
+import Foundation
+
+enum NALUParser {
+
+    /// Parsed parameter sets plus the NAL unit length prefix size.
+    struct ParameterSets: Equatable {
+        var vps: [Data] = []   // HEVC only
+        var sps: [Data] = []
+        var pps: [Data] = []
+        var nalLengthSize: Int = 4
+    }
+
+    // MARK: - Start codes
+
+    static func isStartCode4(_ bytes: [UInt8], _ i: Int) -> Bool {
+        i + 4 <= bytes.count && bytes[i] == 0 && bytes[i + 1] == 0 && bytes[i + 2] == 0 && bytes[i + 3] == 1
+    }
+
+    static func isStartCode3(_ bytes: [UInt8], _ i: Int) -> Bool {
+        i + 3 <= bytes.count && bytes[i] == 0 && bytes[i + 1] == 0 && bytes[i + 2] == 1
+    }
+
+    /// Returns the start-code length (4 or 3) at `i`, or nil if none.
+    static func matchStartCode(_ bytes: [UInt8], _ i: Int) -> Int? {
+        if isStartCode4(bytes, i) { return 4 }
+        if isStartCode3(bytes, i) { return 3 }
+        return nil
+    }
+
+    /// True if the buffer begins with an Annex B start code.
+    static func isAnnexBStartCode(_ bytes: [UInt8]) -> Bool {
+        isStartCode4(bytes, 0) || isStartCode3(bytes, 0)
+    }
+
+    /// True if the buffer contains an Annex B start code anywhere.
+    static func looksLikeAnnexB(_ bytes: [UInt8]) -> Bool {
+        let length = bytes.count
+        if isStartCode4(bytes, 0) { return true }
+        if isStartCode3(bytes, 0) { return true }
+        var i = 0
+        while i + 4 <= length {
+            if isStartCode4(bytes, i) { return true }
+            if isStartCode3(bytes, i) { return true }
+            i += 1
+        }
+        return false
+    }
+
+    // MARK: - Length-prefixed (AVCC / HVCC) extradata
+
+    /// Parses `avcC` (H.264) extradata. Returns nil if malformed or no SPS/PPS found.
+    static func parseAVCC(_ extradata: [UInt8]) -> ParameterSets? {
+        let size = extradata.count
+        guard size >= 7, extradata[0] == 1 else { return nil }
+
+        var result = ParameterSets()
+        result.nalLengthSize = Int(extradata[4] & 0x03) + 1
+        var offset = 5
+
+        let numOfSPS = Int(extradata[offset] & 0x1F)
+        offset += 1
+
+        for _ in 0..<numOfSPS {
+            if offset + 2 > size { return nil }
+            let spsLength = Int(extradata[offset]) << 8 | Int(extradata[offset + 1])
+            offset += 2
+            if offset + spsLength > size { return nil }
+            result.sps.append(Data(extradata[offset..<offset + spsLength]))
+            offset += spsLength
+        }
+
+        if offset + 1 > size { return nil }
+        let numOfPPS = Int(extradata[offset])
+        offset += 1
+
+        for _ in 0..<numOfPPS {
+            if offset + 2 > size { return nil }
+            let ppsLength = Int(extradata[offset]) << 8 | Int(extradata[offset + 1])
+            offset += 2
+            if offset + ppsLength > size { return nil }
+            result.pps.append(Data(extradata[offset..<offset + ppsLength]))
+            offset += ppsLength
+        }
+
+        return (!result.sps.isEmpty && !result.pps.isEmpty) ? result : nil
+    }
+
+    /// Parses `hvcC` (HEVC) extradata. Returns nil if malformed or VPS/SPS/PPS missing.
+    static func parseHVCC(_ extradata: [UInt8]) -> ParameterSets? {
+        let size = extradata.count
+        guard size >= 23, extradata[0] == 1 else { return nil }
+
+        var result = ParameterSets()
+        result.nalLengthSize = Int(extradata[21] & 0x03) + 1
+
+        var offset = 22
+        if offset >= size { return nil }
+
+        let numOfArrays = Int(extradata[offset])
+        offset += 1
+
+        for _ in 0..<numOfArrays {
+            if offset + 3 > size { return nil }
+            let arrayCompletenessAndType = extradata[offset]
+            offset += 1
+            let nalUnitType = Int(arrayCompletenessAndType & 0x3F)
+            let numNalus = Int(extradata[offset]) << 8 | Int(extradata[offset + 1])
+            offset += 2
+
+            for _ in 0..<numNalus {
+                if offset + 2 > size { return nil }
+                let nalUnitLength = Int(extradata[offset]) << 8 | Int(extradata[offset + 1])
+                offset += 2
+                if offset + nalUnitLength > size { return nil }
+                let data = Data(extradata[offset..<offset + nalUnitLength])
+                switch nalUnitType {
+                case 32: result.vps.append(data)
+                case 33: result.sps.append(data)
+                case 34: result.pps.append(data)
+                default: break
+                }
+                offset += nalUnitLength
+            }
+        }
+
+        return (!result.vps.isEmpty && !result.sps.isEmpty && !result.pps.isEmpty) ? result : nil
+    }
+
+    // MARK: - Annex B parameter sets
+
+    /// Walks Annex B extradata collecting VPS/SPS/PPS NAL units. `nalLengthSize` is 4.
+    static func parseAnnexBParameterSets(_ extradata: [UInt8], isHEVC: Bool) -> ParameterSets {
+        var result = ParameterSets()
+        var index = 0
+        while let (range, naluType) = nextAnnexBNAL(in: extradata, start: index, isHEVC: isHEVC) {
+            let data = Data(extradata[range])
+            if isHEVC {
+                switch naluType {
+                case 32: result.vps.append(data)
+                case 33: result.sps.append(data)
+                case 34: result.pps.append(data)
+                default: break
+                }
+            } else {
+                if naluType == 7 {
+                    result.sps.append(data)
+                } else if naluType == 8 {
+                    result.pps.append(data)
+                }
+            }
+            index = range.upperBound
+        }
+        return result
+    }
+
+    /// Finds the next Annex B NAL unit at or after `start`.
+    /// Returns the payload range (excluding the start code) and the NAL unit type.
+    static func nextAnnexBNAL(in bytes: [UInt8], start: Int, isHEVC: Bool) -> (range: Range<Int>, naluType: Int)? {
+        let size = bytes.count
+        var i = start
+
+        var scLen1: Int?
+        while i < size {
+            if let sc = matchStartCode(bytes, i) {
+                scLen1 = sc
+                break
+            }
+            i += 1
+        }
+        guard let sc1 = scLen1 else { return nil }
+        let naluStart = i + sc1
+
+        var j = naluStart
+        var nextStartIdx: Int?
+        while j < size {
+            if matchStartCode(bytes, j) != nil {
+                nextStartIdx = j
+                break
+            }
+            j += 1
+        }
+        let naluEnd = nextStartIdx ?? size
+        guard naluEnd > naluStart else { return nil }
+
+        let firstByte = bytes[naluStart]
+        let naluType: Int
+        if isHEVC {
+            naluType = Int((firstByte >> 1) & 0x3F)
+        } else {
+            naluType = Int(firstByte & 0x1F)
+        }
+        return (naluStart..<naluEnd, naluType)
+    }
+
+    // MARK: - Annex B -> AVCC conversion
+
+    /// Converts an Annex B buffer into a length-prefixed buffer using `nalLengthSize`
+    /// byte big-endian length prefixes. Returns empty `Data` if no NAL units found.
+    static func convertAnnexBToAVCC(_ bytes: [UInt8], nalLengthSize: Int) -> Data {
+        let length = bytes.count
+        var nalRanges: [(start: Int, end: Int)] = []
+        var i = 0
+
+        while i < length {
+            guard let scLen = matchStartCode(bytes, i) else {
+                i += 1
+                continue
+            }
+            let naluStart = i + scLen
+            var j = naluStart
+            var nextStart: Int?
+            while j < length {
+                if matchStartCode(bytes, j) != nil {
+                    nextStart = j
+                    break
+                }
+                j += 1
+            }
+            let naluEnd = nextStart ?? length
+            if naluEnd > naluStart {
+                nalRanges.append((start: naluStart, end: naluEnd))
+            }
+            i = naluEnd
+        }
+
+        if nalRanges.isEmpty { return Data() }
+
+        var out = Data()
+        out.reserveCapacity(nalRanges.reduce(0) { $0 + nalLengthSize + ($1.end - $1.start) })
+
+        for r in nalRanges {
+            let nalSize = r.end - r.start
+            // Write length (big-endian)
+            for b in stride(from: nalLengthSize - 1, through: 0, by: -1) {
+                out.append(UInt8((nalSize >> (b * 8)) & 0xFF))
+            }
+            // Write NALU payload
+            out.append(contentsOf: bytes[r.start..<r.end])
+        }
+        return out
+    }
+}

--- a/IRIPCamera-swift/Stream/NALUParser.swift
+++ b/IRIPCamera-swift/Stream/NALUParser.swift
@@ -24,28 +24,37 @@ enum NALUParser {
 
     // MARK: - Start codes
 
-    static func isStartCode4(_ bytes: [UInt8], _ i: Int) -> Bool {
+    // These operate on any zero-based, integer-indexed byte collection so the
+    // decode hot path can pass an `UnsafeBufferPointer` directly (no array copy)
+    // while tests pass `[UInt8]`.
+
+    static func isStartCode4<C: RandomAccessCollection>(_ bytes: C, _ i: Int) -> Bool
+        where C.Element == UInt8, C.Index == Int {
         i + 4 <= bytes.count && bytes[i] == 0 && bytes[i + 1] == 0 && bytes[i + 2] == 0 && bytes[i + 3] == 1
     }
 
-    static func isStartCode3(_ bytes: [UInt8], _ i: Int) -> Bool {
+    static func isStartCode3<C: RandomAccessCollection>(_ bytes: C, _ i: Int) -> Bool
+        where C.Element == UInt8, C.Index == Int {
         i + 3 <= bytes.count && bytes[i] == 0 && bytes[i + 1] == 0 && bytes[i + 2] == 1
     }
 
     /// Returns the start-code length (4 or 3) at `i`, or nil if none.
-    static func matchStartCode(_ bytes: [UInt8], _ i: Int) -> Int? {
+    static func matchStartCode<C: RandomAccessCollection>(_ bytes: C, _ i: Int) -> Int?
+        where C.Element == UInt8, C.Index == Int {
         if isStartCode4(bytes, i) { return 4 }
         if isStartCode3(bytes, i) { return 3 }
         return nil
     }
 
     /// True if the buffer begins with an Annex B start code.
-    static func isAnnexBStartCode(_ bytes: [UInt8]) -> Bool {
+    static func isAnnexBStartCode<C: RandomAccessCollection>(_ bytes: C) -> Bool
+        where C.Element == UInt8, C.Index == Int {
         isStartCode4(bytes, 0) || isStartCode3(bytes, 0)
     }
 
     /// True if the buffer contains an Annex B start code anywhere.
-    static func looksLikeAnnexB(_ bytes: [UInt8]) -> Bool {
+    static func looksLikeAnnexB<C: RandomAccessCollection>(_ bytes: C) -> Bool
+        where C.Element == UInt8, C.Index == Int {
         let length = bytes.count
         if isStartCode4(bytes, 0) { return true }
         if isStartCode3(bytes, 0) { return true }
@@ -208,7 +217,8 @@ enum NALUParser {
 
     /// Converts an Annex B buffer into a length-prefixed buffer using `nalLengthSize`
     /// byte big-endian length prefixes. Returns empty `Data` if no NAL units found.
-    static func convertAnnexBToAVCC(_ bytes: [UInt8], nalLengthSize: Int) -> Data {
+    static func convertAnnexBToAVCC<C: RandomAccessCollection>(_ bytes: C, nalLengthSize: Int) -> Data
+        where C.Element == UInt8, C.Index == Int {
         let length = bytes.count
         var nalRanges: [(start: Int, end: Int)] = []
         var i = 0

--- a/IRIPCamera-swiftTests/AddressConnectorTests.swift
+++ b/IRIPCamera-swiftTests/AddressConnectorTests.swift
@@ -1,0 +1,108 @@
+//
+//  AddressConnectorTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Exercises the retry / failure escalation in `AddressConnector` using an
+//  injected mock HTTP client (no real networking).
+//
+
+import Testing
+@testable import IRIPCamera_swift
+
+/// Records issued requests instead of hitting the network.
+private final class MockHttpRequest: HttpRequesting {
+    private(set) var requests: [(url: String, callbackID: DeviceConnectorCommandStatus)] = []
+
+    func doJsonRequest(
+        token: String?,
+        url: String,
+        method: HttpRequestMethod,
+        callbackID: DeviceConnectorCommandStatus,
+        target: HttpRequestDelegate
+    ) {
+        requests.append((url, callbackID))
+    }
+
+    func count(of callbackID: DeviceConnectorCommandStatus) -> Int {
+        requests.filter { $0.callbackID == callbackID }.count
+    }
+}
+
+private final class SpyCommanderDelegate: HttpAPICommanderDelegate {
+    private(set) var loginResults: [Int] = []
+    private(set) var rtspResponses: [Int] = []
+    private(set) var twoWayResults: [Int] = []
+
+    func failedAfterRetry(_ caller: HttpAPICommander) {}
+    func didLoginResult(resultCode: Int, message: String, caller: HttpAPICommander, info: [String : Any]?, address: String, port: MultiPort) {
+        loginResults.append(resultCode)
+    }
+    func didGetRTSPResponse(resultCode: Int, message: String) {
+        rtspResponses.append(resultCode)
+    }
+    func didGetRtspURLByChannel(resultCode: Int, message: String?, channel: Int, url: String, ipRatio: Int) {}
+    func didGetTwoWayAudioResponse(resultCode: Int, message: String) {}
+    func didGetTwoWayAudioResult(resultCode: Int, url: String?, type: String?, sampleRate: Int, bps: Int) {
+        twoWayResults.append(resultCode)
+    }
+    func didReportFileDownloadPort(resultCode: Int, message: String, port: Int) {}
+    func didInTheSameLAN(deviceAddress: String, port: MultiPort) {}
+}
+
+struct AddressConnectorTests {
+
+    private func makeConnector() -> (AddressConnector, MockHttpRequest, SpyCommanderDelegate) {
+        let connector = AddressConnector(address: "10.0.0.1", port: .zero(), user: "u", password: "p", scheme: "https")
+        let mock = MockHttpRequest()
+        let delegate = SpyCommanderDelegate()
+        connector.httpRequest = mock
+        connector.delegate = delegate
+        return (connector, mock, delegate)
+    }
+
+    @Test func videoInfoRetriesThreeTimesThenFails() {
+        let (connector, mock, delegate) = makeConnector()
+
+        // Four consecutive failures: 3 retries, then escalate to the delegate.
+        for _ in 0..<4 {
+            connector.failToStaticRequest(errorCode: 500, description: "boom", callbackID: .getVideoInfo)
+        }
+
+        #expect(mock.count(of: .getVideoInfo) == 3)
+        #expect(delegate.rtspResponses == [-2])
+    }
+
+    @Test func twoWayAudioRetriesThreeTimesThenFails() {
+        let (connector, mock, delegate) = makeConnector()
+
+        for _ in 0..<4 {
+            connector.failToStaticRequest(errorCode: 500, description: "boom", callbackID: .getTwoWayAudioInfo)
+        }
+
+        #expect(mock.count(of: .getTwoWayAudioInfo) == 3)
+        #expect(delegate.twoWayResults == [-1])
+    }
+
+    @Test func loginRetriesThreeTimesThenFails() {
+        let (connector, mock, delegate) = makeConnector()
+
+        for _ in 0..<4 {
+            connector.failToStaticRequest(errorCode: 401, description: "auth", callbackID: .doDeviceLogin)
+        }
+
+        // Login retries do not go through the JSON request helper.
+        #expect(mock.requests.isEmpty)
+        #expect(delegate.loginResults == [-1])
+    }
+
+    @Test func failureIsIgnoredAfterCancellation() {
+        let (connector, mock, delegate) = makeConnector()
+        connector.cancelLoginToDevice() // sets stopConnection = true
+
+        connector.failToStaticRequest(errorCode: 500, description: "boom", callbackID: .getVideoInfo)
+
+        #expect(mock.requests.isEmpty)
+        #expect(delegate.rtspResponses.isEmpty)
+        #expect(connector.retryTime == 0)
+    }
+}

--- a/IRIPCamera-swiftTests/AddressConnectorTests.swift
+++ b/IRIPCamera-swiftTests/AddressConnectorTests.swift
@@ -32,6 +32,7 @@ private final class SpyCommanderDelegate: HttpAPICommanderDelegate {
     private(set) var loginResults: [Int] = []
     private(set) var rtspResponses: [Int] = []
     private(set) var twoWayResults: [Int] = []
+    private(set) var rtspURLChannels: [Int] = []
 
     func failedAfterRetry(_ caller: HttpAPICommander) {}
     func didLoginResult(resultCode: Int, message: String, caller: HttpAPICommander, info: [String : Any]?, address: String, port: MultiPort) {
@@ -40,7 +41,9 @@ private final class SpyCommanderDelegate: HttpAPICommanderDelegate {
     func didGetRTSPResponse(resultCode: Int, message: String) {
         rtspResponses.append(resultCode)
     }
-    func didGetRtspURLByChannel(resultCode: Int, message: String?, channel: Int, url: String, ipRatio: Int) {}
+    func didGetRtspURLByChannel(resultCode: Int, message: String?, channel: Int, url: String, ipRatio: Int) {
+        rtspURLChannels.append(channel)
+    }
     func didGetTwoWayAudioResponse(resultCode: Int, message: String) {}
     func didGetTwoWayAudioResult(resultCode: Int, url: String?, type: String?, sampleRate: Int, bps: Int) {
         twoWayResults.append(resultCode)
@@ -93,6 +96,15 @@ struct AddressConnectorTests {
         // Login retries do not go through the JSON request helper.
         #expect(mock.requests.isEmpty)
         #expect(delegate.loginResults == [-1])
+    }
+
+    @Test func getVideoStreamURLReportsThroughDelegate() {
+        let (connector, _, delegate) = makeConnector()
+
+        connector.getVideoStreamURL(byChannel: 2)
+
+        // The base address connector reports channel 0 with an empty URL.
+        #expect(delegate.rtspURLChannels == [0])
     }
 
     @Test func failureIsIgnoredAfterCancellation() {

--- a/IRIPCamera-swiftTests/ConnectorStubsTests.swift
+++ b/IRIPCamera-swiftTests/ConnectorStubsTests.swift
@@ -105,8 +105,10 @@ struct ConnectorStubsTests {
     // MARK: - HttpRequest housekeeping
 
     @Test func doJsonRequestIgnoresInvalidURL() {
+        // Use an isolated instance so the shared singleton is not touched.
+        let request = HttpRequest()
         let target = NoopHttpRequestTarget()
-        HttpRequest.shared.doJsonRequest(
+        request.doJsonRequest(
             token: nil,
             url: "not a valid url",
             method: .get,
@@ -119,7 +121,8 @@ struct ConnectorStubsTests {
     }
 
     @Test func housekeepingCallsAreSafe() {
-        HttpRequest.shared.cleanCamCheck()
-        HttpRequest.shared.destroySharedInstance()
+        let request = HttpRequest()
+        request.cleanCamCheck()
+        request.destroySharedInstance()
     }
 }

--- a/IRIPCamera-swiftTests/ConnectorStubsTests.swift
+++ b/IRIPCamera-swiftTests/ConnectorStubsTests.swift
@@ -1,0 +1,125 @@
+//
+//  ConnectorStubsTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Exercises the base `HttpAPICommander` stubs, `DeviceConnector` pass-through
+//  methods, `DeviceClass.stopConnectionAction`, and `HttpRequest` housekeeping.
+//
+
+import Foundation
+import Testing
+@testable import IRIPCamera_swift
+
+private final class NoopDeviceConnectorDelegate: DeviceConnectorDelegate {
+    func didGetRTSPResponse(resultCode: Int, message: String) {}
+    func didGetRTSPUrlResult(resultCode: Int, message: String, channel: Int, url: String, ipRatio: Int) {}
+    func didGetTwoWayAudioResponse(resultCode: Int, message: String) {}
+    func didGetTwoWayAudioResult(resultCode: Int, url: String, type: String, sampleRate: Int, bps: Int) {}
+}
+
+private final class NoopHttpRequestTarget: HttpRequestDelegate {
+    private(set) var finished = 0
+    private(set) var failed = 0
+    func didFinishStaticRequestJSON(response: Any, callbackID: DeviceConnectorCommandStatus) { finished += 1 }
+    func failToStaticRequest(errorCode code: Int, description: String, callbackID: DeviceConnectorCommandStatus) { failed += 1 }
+}
+
+struct ConnectorStubsTests {
+
+    // MARK: - HttpAPICommander base
+
+    @Test func baseCommanderStubsAreCallable() {
+        let commander = HttpAPICommander(address: "a", port: .zero(), user: "u", password: "p", scheme: "https")
+
+        commander.startLoginToDevice()
+        commander.getVideoStreamURL(byChannel: 0)
+        commander.getTwoWayAudioInfo()
+        commander.closeTwoWayAudio()
+        commander.checkDeviceOnline()
+        #expect(commander.getStreamsCodecInfo() == nil)
+
+        commander.updateUserName("newUser", password: "newPass")
+        #expect(commander.userName == "newUser")
+        #expect(commander.password == "newPass")
+
+        commander.cancelLoginToDevice()
+        #expect(commander.stopConnection)
+    }
+
+    // MARK: - DeviceConnector pass-throughs
+
+    @Test func deviceConnectorForwardsToAddressConnector() {
+        let delegate = NoopDeviceConnectorDelegate()
+        // Distinct, non-empty addresses force creation of an AddressConnector.
+        let connector = DeviceConnector(
+            address: GroupAddress(dataAddress: "10.0.0.1", commandAddress: "10.0.0.2"),
+            port: GroupPort(dataMultiPort: .zero(), commandMultiPort: .zero()),
+            user: "u",
+            password: "p",
+            delegate: delegate,
+            deviceInfo: nil,
+            scheme: "https"
+        )
+
+        #expect(connector.getStreamsCodecInfo() == nil)
+        connector.updateUserName("u2", password: "p2")
+        connector.getVideoStreamURL(byChannel: 0)
+        connector.getTwoWayAudioInfo()
+        connector.stopConnectionAction()
+        // Pass-throughs must not crash with a real address connector attached.
+    }
+
+    @Test func deviceConnectorHttpCommanderCallbacksAreNoOps() {
+        let connector = DeviceConnector(
+            address: GroupAddress(dataAddress: "", commandAddress: ""),
+            port: GroupPort(dataMultiPort: .zero(), commandMultiPort: .zero()),
+            user: "", password: "", delegate: nil, deviceInfo: nil, scheme: "https"
+        )
+        let caller = HttpAPICommander(address: "", port: .zero(), user: "", password: "", scheme: "https")
+
+        connector.failedAfterRetry(caller)
+        connector.didGetRTSPResponse(resultCode: 0, message: "")
+        connector.didGetRtspURLByChannel(resultCode: 0, message: nil, channel: 0, url: "", ipRatio: 0)
+        connector.didGetTwoWayAudioResponse(resultCode: 0, message: "")
+        connector.didGetTwoWayAudioResult(resultCode: 0, url: nil, type: nil, sampleRate: 0, bps: 0)
+        connector.didReportFileDownloadPort(resultCode: 0, message: "", port: 0)
+        connector.didInTheSameLAN(deviceAddress: "", port: .zero())
+        // All are intentional no-ops; this just guards against regressions/crashes.
+    }
+
+    // MARK: - DeviceClass
+
+    @Test func stopConnectionActionReleasesConnector() {
+        let device = DeviceClass()
+        device.connector = DeviceConnector(
+            address: GroupAddress(dataAddress: "10.0.0.1", commandAddress: "10.0.0.2"),
+            port: GroupPort(dataMultiPort: .zero(), commandMultiPort: .zero()),
+            user: "u", password: "p", delegate: nil, deviceInfo: nil, scheme: "https"
+        )
+
+        device.stopConnectionAction()
+
+        #expect(device.connector == nil)
+    }
+
+    // MARK: - HttpRequest housekeeping
+
+    @Test func doJsonRequestIgnoresInvalidURL() {
+        let target = NoopHttpRequestTarget()
+        HttpRequest.shared.doJsonRequest(
+            token: nil,
+            url: "not a valid url",
+            method: .get,
+            callbackID: .getVideoInfo,
+            target: target
+        )
+        // Invalid URL is rejected before any request is made.
+        #expect(target.finished == 0)
+        #expect(target.failed == 0)
+    }
+
+    @Test func housekeepingCallsAreSafe() {
+        HttpRequest.shared.cleanCamCheck()
+        HttpRequest.shared.destroySharedInstance()
+    }
+}

--- a/IRIPCamera-swiftTests/CustomStreamConnectorTests.swift
+++ b/IRIPCamera-swiftTests/CustomStreamConnectorTests.swift
@@ -1,0 +1,74 @@
+//
+//  CustomStreamConnectorTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Covers `IRCustomStreamConnector`'s device-connector delegate reactions
+//  while no live `DeviceConnector` is attached.
+//
+
+import Testing
+@testable import IRIPCamera_swift
+
+private final class SpyConnectorDelegate: IRStreamConnectorDelegate {
+    private(set) var startedResponses: [IRStreamConnectionResponse?] = []
+    private(set) var failures: [ConnectorErrorType] = []
+
+    func connectFail(byType type: ConnectorErrorType, errorDesc: String?) {
+        failures.append(type)
+    }
+    func startStreaming(with response: IRStreamConnectionResponse?) {
+        startedResponses.append(response)
+    }
+}
+
+struct CustomStreamConnectorTests {
+
+    private func makeConnector() -> (IRCustomStreamConnector, SpyConnectorDelegate) {
+        let connector = IRCustomStreamConnector()
+        connector.deviceInfo = DeviceClass()
+        connector.response = IRStreamConnectionResponse()
+        let delegate = SpyConnectorDelegate()
+        connector.delegate = delegate
+        return (connector, delegate)
+    }
+
+    @Test func rtspResponseIncrementsRetryWithoutConnector() {
+        let (connector, _) = makeConnector()
+        connector.didGetRTSPResponse(resultCode: 0, message: "")
+        #expect(connector.videoRetry == 1)
+    }
+
+    @Test func successfulLoginRecordsModelName() {
+        let (connector, _) = makeConnector()
+        connector.didFinishLoginAction(resultType: 0, deviceInfo: ["ModelName": "Cam"], errorDesc: "", address: "", port: .zero())
+        #expect(connector.response?.deviceModelName == "Cam")
+    }
+
+    @Test func loginTimeoutReportsConnectFail() {
+        let (connector, delegate) = makeConnector()
+        connector.didFinishLoginAction(resultType: -1, deviceInfo: nil, errorDesc: "x", address: "", port: .zero())
+        #expect(delegate.failures == [.connectionTimeout])
+    }
+
+    @Test func rtspURLResultStartsStreaming() {
+        let (connector, delegate) = makeConnector()
+        connector.didGetRTSPUrlResult(resultCode: 0, message: "", channel: 0, url: "rtsp://ok", ipRatio: 0)
+        #expect(delegate.startedResponses.count == 1)
+        #expect(connector.response?.rtspURL == "rtsp://ok")
+    }
+
+    @Test func rtspURLFailureIsIgnored() {
+        let (connector, delegate) = makeConnector()
+        connector.didGetRTSPUrlResult(resultCode: -1, message: "", channel: 0, url: "rtsp://x", ipRatio: 0)
+        #expect(delegate.startedResponses.isEmpty)
+    }
+
+    @Test func twoWayAudioCallbacksAreSafeWithoutConnector() {
+        let (connector, _) = makeConnector()
+        connector.didGetTwoWayAudioResponse(resultCode: 0, message: "")
+        connector.didGetTwoWayAudioResult(resultCode: 0, url: "", type: "", sampleRate: 0, bps: 0)
+        connector.changeStream(1)
+        connector.stopStreaming(false)
+        // No connector attached: nothing should crash.
+    }
+}

--- a/IRIPCamera-swiftTests/DelayedTaskTests.swift
+++ b/IRIPCamera-swiftTests/DelayedTaskTests.swift
@@ -1,0 +1,50 @@
+//
+//  DelayedTaskTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Covers the scheduling / cancellation behaviour of `DelayedTask`.
+//
+
+import Foundation
+import Testing
+@testable import IRIPCamera_swift
+
+@MainActor
+struct DelayedTaskTests {
+
+    @Test func runsScheduledWorkAfterDelay() async {
+        let task = DelayedTask()
+
+        let didRun: Bool = await withCheckedContinuation { continuation in
+            task.schedule(after: 0.02) {
+                continuation.resume(returning: true)
+            }
+        }
+
+        #expect(didRun)
+    }
+
+    @Test func cancelPreventsExecution() async throws {
+        let task = DelayedTask()
+        var ran = false
+
+        task.schedule(after: 0.05) { ran = true }
+        task.cancel()
+
+        try await Task.sleep(nanoseconds: 150_000_000)
+        #expect(ran == false)
+    }
+
+    @Test func reschedulingCancelsPreviousWork() async throws {
+        let task = DelayedTask()
+        var firstRan = false
+        var secondRan = false
+
+        task.schedule(after: 0.05) { firstRan = true }
+        task.schedule(after: 0.05) { secondRan = true }
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(firstRan == false)
+        #expect(secondRan == true)
+    }
+}

--- a/IRIPCamera-swiftTests/DeviceClassTests.swift
+++ b/IRIPCamera-swiftTests/DeviceClassTests.swift
@@ -1,0 +1,72 @@
+//
+//  DeviceClassTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Covers `DeviceClass` defaults and its `NSCopying` implementation.
+//
+
+import Testing
+@testable import IRIPCamera_swift
+
+private final class SpyDeviceDelegate: DeviceClassDelegate {
+    private(set) var finishedCount = 0
+    func didDeviceStatusFinish(_ device: DeviceClass) { finishedCount += 1 }
+}
+
+struct DeviceClassTests {
+
+    @Test func freshDeviceHasEmptyDefaults() {
+        let device = DeviceClass()
+        #expect(device.deviceName.isEmpty)
+        #expect(device.deviceAddress.isEmpty)
+        #expect(device.userName.isEmpty)
+        #expect(device.password.isEmpty)
+        #expect(device.streamInfo == "")
+        #expect(device.httpPort == MultiPort.initial())
+        #expect(device.connector == nil)
+    }
+
+    @Test func copyDuplicatesValueFields() {
+        let original = DeviceClass()
+        original.deviceName = "Front Door"
+        original.deviceAddress = "192.168.1.50"
+        original.userName = "admin"
+        original.password = "secret"
+        original.streamInfo = "main"
+        original.httpPort = MultiPort(httpsPort: 1, videoPort: 2, audioPort: 3, normalPort: 4)
+
+        let copy = original.copy() as! DeviceClass
+
+        #expect(copy !== original)
+        #expect(copy.deviceName == "Front Door")
+        #expect(copy.deviceAddress == "192.168.1.50")
+        #expect(copy.userName == "admin")
+        #expect(copy.password == "secret")
+        #expect(copy.streamInfo == "main")
+        #expect(copy.httpPort == original.httpPort)
+    }
+
+    @Test func copyDoesNotCarryDelegate() {
+        let original = DeviceClass()
+        original.delegate = SpyDeviceDelegate()
+
+        let copy = original.copy() as! DeviceClass
+
+        #expect(copy.delegate == nil)
+    }
+
+    @Test func getWideDegreeValueIsZero() {
+        #expect(DeviceClass().getWideDegreeValue() == 0)
+    }
+
+    @Test func httpRequestCallbacksNotifyDelegate() {
+        let device = DeviceClass()
+        let delegate = SpyDeviceDelegate()
+        device.delegate = delegate
+
+        device.didFinishStaticRequestJSON(response: [:], callbackID: .doDeviceLogin)
+        device.failToStaticRequest(errorCode: 1, description: "x", callbackID: .getVideoInfo)
+
+        #expect(delegate.finishedCount == 2)
+    }
+}

--- a/IRIPCamera-swiftTests/DeviceConnectorTests.swift
+++ b/IRIPCamera-swiftTests/DeviceConnectorTests.swift
@@ -1,0 +1,95 @@
+//
+//  DeviceConnectorTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Covers `DeviceConnector` login guard and delegate forwarding.
+//
+
+import Foundation
+import Testing
+@testable import IRIPCamera_swift
+
+private final class SpyDeviceConnectorDelegate: DeviceConnectorDelegate {
+    struct LoginAction {
+        let resultType: Int
+        let errorDesc: String
+        let address: String
+        let deviceInfo: [String: Any]?
+    }
+
+    private let lock = NSLock()
+    private var _loginActions: [LoginAction] = []
+    var loginActions: [LoginAction] {
+        lock.lock(); defer { lock.unlock() }
+        return _loginActions
+    }
+
+    func didFinishLoginAction(resultType: Int, deviceInfo: [String : Any]?, errorDesc: String, address: String, port: MultiPort) {
+        lock.lock(); defer { lock.unlock() }
+        _loginActions.append(LoginAction(resultType: resultType, errorDesc: errorDesc, address: address, deviceInfo: deviceInfo))
+    }
+
+    // Required members without protocol defaults.
+    func didGetRTSPResponse(resultCode: Int, message: String) {}
+    func didGetRTSPUrlResult(resultCode: Int, message: String, channel: Int, url: String, ipRatio: Int) {}
+    func didGetTwoWayAudioResponse(resultCode: Int, message: String) {}
+    func didGetTwoWayAudioResult(resultCode: Int, url: String, type: String, sampleRate: Int, bps: Int) {}
+}
+
+struct DeviceConnectorTests {
+
+    private func makeConnector(delegate: DeviceConnectorDelegate) -> DeviceConnector {
+        DeviceConnector(
+            address: GroupAddress(dataAddress: "", commandAddress: ""),
+            port: GroupPort(dataMultiPort: .zero(), commandMultiPort: .zero()),
+            user: "",
+            password: "",
+            delegate: delegate,
+            deviceInfo: nil,
+            scheme: "https"
+        )
+    }
+
+    @Test func loginFailsWhenNoConnectorAvailable() async throws {
+        let delegate = SpyDeviceConnectorDelegate()
+        let connector = makeConnector(delegate: delegate)
+
+        connector.loginToDevice(getRTSPInfo: true, checkPrevious: false, ignoreLoginCache: true)
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(delegate.loginActions.map(\.resultType) == [-1])
+        #expect(delegate.loginActions.first?.errorDesc == "Connect failed")
+    }
+
+    @Test func checkOnlineStatusFailsWhenNoConnectorAvailable() async throws {
+        let delegate = SpyDeviceConnectorDelegate()
+        let connector = makeConnector(delegate: delegate)
+
+        connector.startCheckOnlineStatus()
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(delegate.loginActions.map(\.resultType) == [-1])
+    }
+
+    @Test func loginResultIsForwardedToDelegate() {
+        let delegate = SpyDeviceConnectorDelegate()
+        let connector = makeConnector(delegate: delegate)
+        let caller = HttpAPICommander(address: "", port: .zero(), user: "", password: "", scheme: "https")
+
+        connector.didLoginResult(
+            resultCode: 0,
+            message: "ok",
+            caller: caller,
+            info: ["ModelName": "Cam"],
+            address: "1.2.3.4",
+            port: .zero()
+        )
+
+        #expect(delegate.loginActions.count == 1)
+        let action = delegate.loginActions.first
+        #expect(action?.resultType == 0)
+        #expect(action?.errorDesc == "ok")
+        #expect(action?.address == "1.2.3.4")
+        #expect(action?.deviceInfo?["ModelName"] as? String == "Cam")
+    }
+}

--- a/IRIPCamera-swiftTests/IRIPCamera_swiftTests.swift
+++ b/IRIPCamera-swiftTests/IRIPCamera_swiftTests.swift
@@ -8,10 +8,29 @@
 import Testing
 @testable import IRIPCamera_swift
 
+/// Smoke tests covering the lightweight value types and shared constants.
 struct IRIPCamera_swiftTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func maxRetryTimesIsThree() {
+        #expect(MAX_RETRY_TIMES == 3)
     }
 
+    @Test func streamConnectionRequestDefaultsToEmptyURL() {
+        #expect(IRStreamConnectionRequest().rtspUrl.isEmpty)
+    }
+
+    @Test func customStreamConnectionRequestRetainsDevice() {
+        let device = DeviceClass()
+        device.deviceName = "cam-1"
+        let request = IRCustomStreamConnectionRequest(device: device)
+        #expect(request.device === device)
+        #expect(request.rtspUrl.isEmpty)
+    }
+
+    @Test func streamConnectionResponseStartsEmpty() {
+        let response = IRStreamConnectionResponse()
+        #expect(response.rtspURL == nil)
+        #expect(response.deviceModelName == nil)
+        #expect(response.streamsInfo == nil)
+    }
 }

--- a/IRIPCamera-swiftTests/MultiPortTests.swift
+++ b/IRIPCamera-swiftTests/MultiPortTests.swift
@@ -1,0 +1,47 @@
+//
+//  MultiPortTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Covers the `MultiPort` value type and the grouping structs it lives in.
+//
+
+import Testing
+@testable import IRIPCamera_swift
+
+struct MultiPortTests {
+
+    @Test func zeroIsAllZeros() {
+        let port = MultiPort.zero()
+        #expect(port.httpsPort == 0)
+        #expect(port.videoPort == 0)
+        #expect(port.audioPort == 0)
+        #expect(port.normalPort == 0)
+    }
+
+    @Test func initialUsesConfiguredConstants() {
+        let port = MultiPort.initial()
+        #expect(port.httpsPort == HTTPS_APP_COMMAND_PORT)
+        #expect(port.videoPort == VIDEO_PORT)
+        #expect(port.audioPort == AUDIO_PORT)
+        #expect(port.normalPort == NORMAL_PORT)
+    }
+
+    @Test func equatableComparesEveryField() {
+        let base = MultiPort(httpsPort: 1, videoPort: 2, audioPort: 3, normalPort: 4)
+        #expect(base == MultiPort(httpsPort: 1, videoPort: 2, audioPort: 3, normalPort: 4))
+        #expect(base != MultiPort(httpsPort: 9, videoPort: 2, audioPort: 3, normalPort: 4))
+        #expect(base != MultiPort(httpsPort: 1, videoPort: 2, audioPort: 3, normalPort: 9))
+    }
+
+    @Test func groupingStructsPreservePorts() {
+        let data = MultiPort(httpsPort: 1, videoPort: 2, audioPort: 3, normalPort: 4)
+        let command = MultiPort.zero()
+        let group = GroupPort(dataMultiPort: data, commandMultiPort: command)
+        #expect(group.dataMultiPort == data)
+        #expect(group.commandMultiPort == command)
+
+        let address = GroupAddress(dataAddress: "10.0.0.1", commandAddress: "10.0.0.2")
+        #expect(address.dataAddress == "10.0.0.1")
+        #expect(address.commandAddress == "10.0.0.2")
+    }
+}

--- a/IRIPCamera-swiftTests/NALUParserTests.swift
+++ b/IRIPCamera-swiftTests/NALUParserTests.swift
@@ -1,0 +1,180 @@
+//
+//  NALUParserTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Covers the pure NAL-unit parsing / conversion logic extracted from
+//  IRStreamVideoDecoder.
+//
+
+import Foundation
+import Testing
+@testable import IRIPCamera_swift
+
+struct NALUParserTests {
+
+    // MARK: - Start codes
+
+    @Test func detectsLeadingStartCodes() {
+        #expect(NALUParser.isAnnexBStartCode([0, 0, 0, 1, 0x67]))
+        #expect(NALUParser.isAnnexBStartCode([0, 0, 1, 0x67]))
+        #expect(!NALUParser.isAnnexBStartCode([1, 2, 3, 4]))
+        #expect(!NALUParser.isAnnexBStartCode([0, 0]))
+    }
+
+    @Test func detectsEmbeddedStartCodes() {
+        #expect(NALUParser.looksLikeAnnexB([0xFF, 0xFF, 0, 0, 1, 0x65]))
+        #expect(NALUParser.looksLikeAnnexB([0, 0, 0, 1, 0x65]))
+        #expect(!NALUParser.looksLikeAnnexB([1, 2, 3, 4, 5]))
+        #expect(!NALUParser.looksLikeAnnexB([]))
+    }
+
+    @Test func matchStartCodePrefersFourByteCode() {
+        #expect(NALUParser.matchStartCode([0, 0, 0, 1], 0) == 4)
+        #expect(NALUParser.matchStartCode([0, 0, 1, 9], 0) == 3)
+        #expect(NALUParser.matchStartCode([9, 0, 0, 1], 0) == nil)
+    }
+
+    // MARK: - avcC (H.264)
+
+    @Test func parsesValidAVCC() {
+        let extradata: [UInt8] = [
+            0x01,                   // configurationVersion
+            0x64, 0x00, 0x1F,       // profile / compat / level
+            0xFF,                   // lengthSizeMinusOne = 3 -> nalLengthSize 4
+            0xE1,                   // numSPS = 1 (top bits reserved)
+            0x00, 0x04,             // SPS length 4
+            0x67, 0x42, 0x00, 0x1F, // SPS payload
+            0x01,                   // numPPS = 1
+            0x00, 0x03,             // PPS length 3
+            0x68, 0xCE, 0x3C        // PPS payload
+        ]
+
+        let sets = NALUParser.parseAVCC(extradata)
+
+        #expect(sets?.nalLengthSize == 4)
+        #expect(sets?.sps == [Data([0x67, 0x42, 0x00, 0x1F])])
+        #expect(sets?.pps == [Data([0x68, 0xCE, 0x3C])])
+        #expect(sets?.vps.isEmpty == true)
+    }
+
+    @Test func parsesAVCCLengthSizeFromHeader() {
+        let extradata: [UInt8] = [
+            0x01, 0x64, 0x00, 0x1F,
+            0xFD,                   // lengthSizeMinusOne = 1 -> nalLengthSize 2
+            0xE1,
+            0x00, 0x02, 0x67, 0x10,
+            0x01,
+            0x00, 0x02, 0x68, 0x20
+        ]
+
+        #expect(NALUParser.parseAVCC(extradata)?.nalLengthSize == 2)
+    }
+
+    @Test func rejectsMalformedAVCC() {
+        #expect(NALUParser.parseAVCC([0x01, 0x64, 0x00]) == nil)          // too short
+        #expect(NALUParser.parseAVCC([0x00, 0x64, 0x00, 0x1F, 0xFF, 0xE1, 0x00]) == nil) // wrong version
+        // SPS length runs past the buffer.
+        #expect(NALUParser.parseAVCC([0x01, 0, 0, 0, 0xFF, 0xE1, 0x00, 0x09, 0x67]) == nil)
+    }
+
+    // MARK: - hvcC (HEVC)
+
+    @Test func parsesValidHVCC() {
+        var d: [UInt8] = Array(repeating: 0, count: 22)
+        d[0] = 0x01
+        d[21] = 0xFF                       // nalLengthSize 4
+        d.append(0x03)                     // numArrays
+        d.append(contentsOf: [0x20, 0x00, 0x01, 0x00, 0x02, 0x40, 0x01]) // VPS (type 32)
+        d.append(contentsOf: [0x21, 0x00, 0x01, 0x00, 0x03, 0x42, 0x01, 0x02]) // SPS (type 33)
+        d.append(contentsOf: [0x22, 0x00, 0x01, 0x00, 0x02, 0x44, 0x01]) // PPS (type 34)
+
+        let sets = NALUParser.parseHVCC(d)
+
+        #expect(sets?.nalLengthSize == 4)
+        #expect(sets?.vps == [Data([0x40, 0x01])])
+        #expect(sets?.sps == [Data([0x42, 0x01, 0x02])])
+        #expect(sets?.pps == [Data([0x44, 0x01])])
+    }
+
+    @Test func rejectsMalformedHVCC() {
+        #expect(NALUParser.parseHVCC(Array(repeating: 0, count: 10)) == nil) // too short
+        var noVersion = Array<UInt8>(repeating: 0, count: 30)
+        noVersion[0] = 0x02
+        #expect(NALUParser.parseHVCC(noVersion) == nil)                       // wrong version
+    }
+
+    // MARK: - Annex B parameter sets
+
+    @Test func parsesAnnexBH264ParameterSets() {
+        let extradata: [UInt8] = [
+            0, 0, 0, 1, 0x67, 0xAA, // SPS (type 7)
+            0, 0, 0, 1, 0x68, 0xBB  // PPS (type 8)
+        ]
+
+        let sets = NALUParser.parseAnnexBParameterSets(extradata, isHEVC: false)
+
+        #expect(sets.sps == [Data([0x67, 0xAA])])
+        #expect(sets.pps == [Data([0x68, 0xBB])])
+        #expect(sets.nalLengthSize == 4)
+    }
+
+    @Test func parsesAnnexBHEVCParameterSets() {
+        let extradata: [UInt8] = [
+            0, 0, 0, 1, 0x40, 0x01, // VPS (type 32)
+            0, 0, 0, 1, 0x42, 0x02, // SPS (type 33)
+            0, 0, 0, 1, 0x44, 0x03  // PPS (type 34)
+        ]
+
+        let sets = NALUParser.parseAnnexBParameterSets(extradata, isHEVC: true)
+
+        #expect(sets.vps == [Data([0x40, 0x01])])
+        #expect(sets.sps == [Data([0x42, 0x02])])
+        #expect(sets.pps == [Data([0x44, 0x03])])
+    }
+
+    @Test func nextAnnexBNALReportsTypeAndRange() {
+        let bytes: [UInt8] = [0, 0, 0, 1, 0x67, 0x42, 0x00]
+        let nal = NALUParser.nextAnnexBNAL(in: bytes, start: 0, isHEVC: false)
+        #expect(nal?.naluType == 7)              // 0x67 & 0x1F
+        #expect(nal?.range == 4..<7)
+
+        let hevc = NALUParser.nextAnnexBNAL(in: bytes, start: 0, isHEVC: true)
+        #expect(hevc?.naluType == 0x33)          // (0x67 >> 1) & 0x3F
+
+        #expect(NALUParser.nextAnnexBNAL(in: [1, 2, 3], start: 0, isHEVC: false) == nil)
+    }
+
+    // MARK: - Annex B -> AVCC conversion
+
+    @Test func convertsAnnexBToFourByteLengthPrefixed() {
+        let annexB: [UInt8] = [
+            0, 0, 0, 1, 0x67, 0x42, // NAL #1
+            0, 0, 1, 0x68           // NAL #2 (3-byte start code)
+        ]
+
+        let avcc = NALUParser.convertAnnexBToAVCC(annexB, nalLengthSize: 4)
+
+        #expect(avcc == Data([0, 0, 0, 2, 0x67, 0x42, 0, 0, 0, 1, 0x68]))
+    }
+
+    @Test func convertsAnnexBWithTwoByteLengthPrefix() {
+        let annexB: [UInt8] = [0, 0, 0, 1, 0x65, 0x11, 0x22]
+
+        let avcc = NALUParser.convertAnnexBToAVCC(annexB, nalLengthSize: 2)
+
+        #expect(avcc == Data([0, 3, 0x65, 0x11, 0x22]))
+    }
+
+    @Test func convertReturnsEmptyWhenNoStartCode() {
+        #expect(NALUParser.convertAnnexBToAVCC([1, 2, 3, 4], nalLengthSize: 4).isEmpty)
+    }
+
+    @Test func roundTripsAVCCParametersThroughConversion() {
+        // An Annex B access unit converted to AVCC should round-trip the payloads
+        // when parsed back with a matching length size.
+        let annexB: [UInt8] = [0, 0, 0, 1, 0x67, 0x01, 0x02, 0, 0, 0, 1, 0x68, 0x03]
+        let avcc = NALUParser.convertAnnexBToAVCC(annexB, nalLengthSize: 4)
+        // 4-byte len (3) + [67,01,02] + 4-byte len (2) + [68,03]
+        #expect(avcc == Data([0, 0, 0, 3, 0x67, 0x01, 0x02, 0, 0, 0, 2, 0x68, 0x03]))
+    }
+}

--- a/IRIPCamera-swiftTests/StreamConnectionRequestFactoryTests.swift
+++ b/IRIPCamera-swiftTests/StreamConnectionRequestFactoryTests.swift
@@ -1,0 +1,91 @@
+//
+//  StreamConnectionRequestFactoryTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Verifies how `IRStreamConnectionRequestFactory` turns persisted settings
+//  into stream connection requests.
+//
+
+import Foundation
+import Testing
+@testable import IRIPCamera_swift
+
+struct StreamConnectionRequestFactoryTests {
+
+    /// Builds an isolated `UserDefaults` so tests never touch the real domain.
+    private func makeDefaults() -> UserDefaults {
+        let suite = "RequestFactoryTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    @Test func returnsCustomRequestWhenRTSPDisabled() {
+        let defaults = makeDefaults()
+        defaults.set(false, forKey: ENABLE_RTSP_URL_KEY)
+
+        let requests = IRStreamConnectionRequestFactory.createStreamConnectionRequest(userDefaults: defaults)
+
+        #expect(requests.count == 1)
+        #expect(requests.first is IRCustomStreamConnectionRequest)
+    }
+
+    @Test func defaultsToCustomRequestWhenNothingConfigured() {
+        let defaults = makeDefaults()
+
+        let requests = IRStreamConnectionRequestFactory.createStreamConnectionRequest(userDefaults: defaults)
+
+        #expect(requests.count == 1)
+        #expect(requests.first is IRCustomStreamConnectionRequest)
+    }
+
+    @Test func collectsEnabledNonEmptyURLs() {
+        let defaults = makeDefaults()
+        defaults.set(true, forKey: ENABLE_RTSP_URL_KEY)
+        defaults.set("rtsp://a", forKey: RTSP_URL_KEY)
+        defaults.set("rtsp://b", forKey: RTSP_URL_KEY_2)
+        defaults.set("rtsp://c", forKey: RTSP_URL_KEY_3)
+        defaults.set("rtsp://d", forKey: RTSP_URL_KEY_4)
+
+        let requests = IRStreamConnectionRequestFactory.createStreamConnectionRequest(userDefaults: defaults)
+
+        #expect(requests.count == 4)
+        #expect(requests.map(\.rtspUrl) == ["rtsp://a", "rtsp://b", "rtsp://c", "rtsp://d"])
+        #expect(requests.allSatisfy { !($0 is IRCustomStreamConnectionRequest) })
+    }
+
+    @Test func skipsDisabledSlots() {
+        let defaults = makeDefaults()
+        defaults.set(true, forKey: ENABLE_RTSP_URL_KEY)
+        defaults.set("rtsp://a", forKey: RTSP_URL_KEY)
+        defaults.set("rtsp://b", forKey: RTSP_URL_KEY_2)
+        defaults.set(false, forKey: RTSP_URL_ENABLE_KEY_2)
+
+        let requests = IRStreamConnectionRequestFactory.createStreamConnectionRequest(userDefaults: defaults)
+
+        #expect(requests.map(\.rtspUrl) == ["rtsp://a"])
+    }
+
+    @Test func skipsEmptyAndWhitespaceURLs() {
+        let defaults = makeDefaults()
+        defaults.set(true, forKey: ENABLE_RTSP_URL_KEY)
+        defaults.set("", forKey: RTSP_URL_KEY)
+        defaults.set("   \n ", forKey: RTSP_URL_KEY_2)
+        defaults.set("  rtsp://trim  ", forKey: RTSP_URL_KEY_3)
+
+        let requests = IRStreamConnectionRequestFactory.createStreamConnectionRequest(userDefaults: defaults)
+
+        #expect(requests.map(\.rtspUrl) == ["rtsp://trim"])
+    }
+
+    @Test func slotsAreEnabledByDefaultWhenFlagAbsent() {
+        let defaults = makeDefaults()
+        defaults.set(true, forKey: ENABLE_RTSP_URL_KEY)
+        defaults.set("rtsp://a", forKey: RTSP_URL_KEY)
+        // No enable flag set for slot 1 -> should default to enabled.
+
+        let requests = IRStreamConnectionRequestFactory.createStreamConnectionRequest(userDefaults: defaults)
+
+        #expect(requests.map(\.rtspUrl) == ["rtsp://a"])
+    }
+}

--- a/IRIPCamera-swiftTests/StreamConnectorTests.swift
+++ b/IRIPCamera-swiftTests/StreamConnectorTests.swift
@@ -1,0 +1,62 @@
+//
+//  StreamConnectorTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Covers the base `IRStreamConnector` delegate contract.
+//
+
+import Testing
+@testable import IRIPCamera_swift
+
+private final class SpyConnectorDelegate: IRStreamConnectorDelegate {
+    private(set) var startedResponses: [IRStreamConnectionResponse?] = []
+    private(set) var failures: [(type: ConnectorErrorType, desc: String?)] = []
+
+    func connectFail(byType type: ConnectorErrorType, errorDesc: String?) {
+        failures.append((type, errorDesc))
+    }
+
+    func startStreaming(with response: IRStreamConnectionResponse?) {
+        startedResponses.append(response)
+    }
+}
+
+struct StreamConnectorTests {
+
+    @Test func startStreamConnectionForwardsRTSPURLToDelegate() {
+        let connector = IRStreamConnector()
+        let delegate = SpyConnectorDelegate()
+        connector.delegate = delegate
+        connector.rtspURL = "rtsp://camera/live"
+        connector.videoRetry = 7
+
+        connector.startStreamConnection()
+
+        #expect(delegate.startedResponses.count == 1)
+        #expect(connector.response?.rtspURL == "rtsp://camera/live")
+        #expect(delegate.startedResponses.first??.rtspURL == "rtsp://camera/live")
+        // videoRetry must be reset on every fresh connection attempt.
+        #expect(connector.videoRetry == 0)
+    }
+
+    @Test func startStreamConnectionWithoutDelegateStillBuildsResponse() {
+        let connector = IRStreamConnector()
+        connector.rtspURL = "rtsp://camera/2"
+
+        connector.startStreamConnection()
+
+        #expect(connector.response?.rtspURL == "rtsp://camera/2")
+    }
+
+    @Test func baseStopAndChangeStreamAreNoOps() {
+        let connector = IRStreamConnector()
+        let delegate = SpyConnectorDelegate()
+        connector.delegate = delegate
+
+        connector.stopStreaming(true)
+        connector.changeStream(2)
+
+        #expect(delegate.startedResponses.isEmpty)
+        #expect(delegate.failures.isEmpty)
+    }
+}

--- a/IRIPCamera-swiftTests/StreamControllerFactoryTests.swift
+++ b/IRIPCamera-swiftTests/StreamControllerFactoryTests.swift
@@ -1,0 +1,34 @@
+//
+//  StreamControllerFactoryTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Verifies `IRStreamControllerFactory` wires up the right controller flavour
+//  for each request type.
+//
+
+import Testing
+@testable import IRIPCamera_swift
+
+@MainActor
+struct StreamControllerFactoryTests {
+
+    @Test func buildsRTSPControllerForPlainRequest() {
+        let request = IRStreamConnectionRequest()
+        request.rtspUrl = "rtsp://example"
+
+        let controller = IRStreamControllerFactory.createStreamController(by: request)
+
+        // A plain RTSP request must not be treated as a custom-device request.
+        #expect(controller.deviceInfo == nil)
+    }
+
+    @Test func buildsDeviceControllerForCustomRequest() {
+        let device = DeviceClass()
+        device.deviceName = "cam"
+        let request = IRCustomStreamConnectionRequest(device: device)
+
+        let controller = IRStreamControllerFactory.createStreamController(by: request)
+
+        #expect(controller.deviceInfo === device)
+    }
+}

--- a/IRIPCamera-swiftTests/StreamControllerStateTests.swift
+++ b/IRIPCamera-swiftTests/StreamControllerStateTests.swift
@@ -128,4 +128,71 @@ struct StreamControllerStateTests {
         try? await Task.sleep(nanoseconds: 300_000_000)
         #expect(delegate.errors.isEmpty)
     }
+
+    @Test func videoLossTriggersReconnect() async {
+        let (controller, delegate) = makeDeviceController()
+        controller.videoLoss(withErrorCode: 1, msg: "lost")
+        await waitUntil { !delegate.errors.isEmpty }
+        #expect(!delegate.errors.isEmpty)
+    }
+
+    // MARK: - Connector error mapping
+
+    @Test func connectFailMapsEveryErrorType() {
+        let (controller, delegate) = makeRTSPController()
+        controller.connectFail(byType: ConnectorErrorType.authorizationError, errorDesc: nil)
+        controller.connectFail(byType: ConnectorErrorType.notSupported, errorDesc: nil)
+        controller.connectFail(byType: ConnectorErrorType.connectionTimeout, errorDesc: nil)
+        // Each type produces exactly one (non-empty) user-facing message.
+        #expect(delegate.errors.count == 3)
+        #expect(delegate.errors.allSatisfy { !$0.isEmpty })
+    }
+
+    @Test func legacyConnectFailForwardsRawDescription() {
+        let (controller, delegate) = makeRTSPController()
+        controller.connectFail(byType: 5, errorDesc: "boom")
+        #expect(delegate.errors == ["boom"])
+    }
+
+    // MARK: - startStreaming branches
+
+    @Test func startStreamingWithoutURLReportsDisconnect() async {
+        let (controller, delegate) = makeRTSPController()
+        controller.startStreaming(with: IRStreamConnectionResponse())
+        await waitUntil { !delegate.connectResults.isEmpty }
+        #expect(delegate.connectResults == [false])
+    }
+
+    @Test func startStreamingFisheyeWithoutURLReportsDisconnect() async {
+        let (controller, delegate) = makeRTSPController()
+        let response = IRStreamConnectionResponse()
+        response.deviceModelName = "FisheyeCAM"
+        controller.startStreaming(with: response)
+        await waitUntil { !delegate.connectResults.isEmpty }
+        #expect(delegate.connectResults == [false])
+    }
+
+    // MARK: - Render modes / change stream
+
+    @Test func renderModeAccessorsAreSafeWithoutVideoView() {
+        let (controller, _) = makeRTSPController()
+        #expect(controller.getRenderModes().isEmpty)
+        #expect(controller.getCurrentRenderMode() == nil)
+
+        // createFisheyeModes builds the full fisheye mode set.
+        let modes = controller.createFisheyeModes(with: nil)
+        #expect(modes.count == 4)
+
+        // Setting a mode without a video view must not crash.
+        if let first = modes.first {
+            controller.setCurrentRenderMode(first)
+        }
+    }
+
+    @Test func changeStreamReportsDisconnect() async {
+        let (controller, delegate) = makeRTSPController()
+        controller.changeStream(1)
+        await waitUntil { !delegate.connectResults.isEmpty }
+        #expect(delegate.connectResults == [false])
+    }
 }

--- a/IRIPCamera-swiftTests/StreamControllerStateTests.swift
+++ b/IRIPCamera-swiftTests/StreamControllerStateTests.swift
@@ -1,0 +1,131 @@
+//
+//  StreamControllerStateTests.swift
+//  IRIPCamera-swiftTests
+//
+//  Covers `IRStreamController`'s playback state machine and connector-delegate
+//  reactions. The IRPlayer-typed `updatedVideoModes` callback is intentionally
+//  left to its protocol default so the test target needs no IRPlayer import.
+//
+
+import Foundation
+import Testing
+@testable import IRIPCamera_swift
+
+private final class SpyControllerDelegate: IRStreamControllerDelegate {
+    private let lock = NSLock()
+    private var _statuses: [IRStreamControllerStatus] = []
+    private var _errors: [String] = []
+    private var _connectResults: [Bool] = []
+
+    var statuses: [IRStreamControllerStatus] { lock.lock(); defer { lock.unlock() }; return _statuses }
+    var errors: [String] { lock.lock(); defer { lock.unlock() }; return _errors }
+    var connectResults: [Bool] { lock.lock(); defer { lock.unlock() }; return _connectResults }
+
+    func connectResult(_ videoView: Any, connection: Bool, micSupport: Bool, speakerSupport: Bool) {
+        lock.lock(); _connectResults.append(connection); lock.unlock()
+    }
+    func showErrorMessage(_ msg: String) {
+        lock.lock(); _errors.append(msg); lock.unlock()
+    }
+    func streamControllerStatusChanged(_ status: IRStreamControllerStatus) {
+        lock.lock(); _statuses.append(status); lock.unlock()
+    }
+    // updatedVideoModes(_:) intentionally uses the protocol default.
+}
+
+@MainActor
+struct StreamControllerStateTests {
+
+    private func waitUntil(timeout: TimeInterval = 1.0, _ condition: () -> Bool) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    private func makeRTSPController() -> (IRStreamController, SpyControllerDelegate) {
+        let controller = IRStreamController(rtspURL: "rtsp://example/live")
+        let delegate = SpyControllerDelegate()
+        controller.eventDelegate = delegate
+        return (controller, delegate)
+    }
+
+    private func makeDeviceController() -> (IRStreamController, SpyControllerDelegate) {
+        let controller = IRStreamController(device: DeviceClass())
+        let delegate = SpyControllerDelegate()
+        controller.eventDelegate = delegate
+        return (controller, delegate)
+    }
+
+    // MARK: - State machine
+
+    @Test func bufferingStateReportsBufferingStatus() {
+        let (controller, delegate) = makeRTSPController()
+        controller.handle(playbackState: .buffering)
+        #expect(delegate.statuses == [.buffering])
+    }
+
+    @Test func playingStateReportsPlayingStatus() {
+        let (controller, delegate) = makeRTSPController()
+        controller.handle(playbackState: .playing)
+        #expect(delegate.statuses == [.playing])
+    }
+
+    @Test func otherStateIsIgnored() {
+        let (controller, delegate) = makeRTSPController()
+        controller.handle(playbackState: .other)
+        #expect(delegate.statuses.isEmpty)
+        #expect(delegate.errors.isEmpty)
+        #expect(delegate.connectResults.isEmpty)
+    }
+
+    @Test func readyToPlayReportsSuccessfulConnection() async {
+        let (controller, delegate) = makeRTSPController()
+        controller.handle(playbackState: .readyToPlay)
+        await waitUntil { !delegate.connectResults.isEmpty }
+        #expect(delegate.connectResults == [true])
+    }
+
+    @Test func stateActionWithEmptyUserInfoIsNoOp() {
+        let (controller, delegate) = makeRTSPController()
+        controller.stateAction(Notification(name: .init("test"), object: nil, userInfo: [:]))
+        #expect(delegate.statuses.isEmpty)
+        #expect(delegate.connectResults.isEmpty)
+    }
+
+    // MARK: - Connector delegate reactions
+
+    @Test func startStreamConnectionAnnouncesPreparing() {
+        let (controller, delegate) = makeRTSPController()
+        controller.startStreamConnection()
+        #expect(delegate.statuses == [.preparingToPlay])
+    }
+
+    @Test func connectFailShowsErrorAndReportsDisconnect() async {
+        let (controller, delegate) = makeRTSPController()
+        controller.connectFail(byType: ConnectorErrorType.authorizationError, errorDesc: nil)
+        #expect(delegate.errors.count == 1)
+        await waitUntil { !delegate.connectResults.isEmpty }
+        #expect(delegate.connectResults == [false])
+    }
+
+    // MARK: - Reconnect (failed state)
+
+    @Test func failedStateTriggersReconnect() async {
+        let (controller, delegate) = makeDeviceController()
+        controller.handle(playbackState: .failed)
+        // Reconnect drives a login attempt that fails (no reachable device),
+        // surfacing an error message back through the delegate.
+        await waitUntil { !delegate.errors.isEmpty }
+        #expect(!delegate.errors.isEmpty)
+    }
+
+    @Test func failedStateDoesNotReconnectAfterStop() async {
+        let (controller, delegate) = makeDeviceController()
+        controller.stopStreaming(stopForever: true)
+        controller.handle(playbackState: .failed)
+        // Give any erroneous reconnect a chance to surface, then assert none did.
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        #expect(delegate.errors.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Builds out a real unit test suite (the target previously had a single empty placeholder), refactoring code for testability along the way and fixing three latent bugs surfaced by the new tests. App-target code coverage rises from **~8% to ~40%**; the logic layer (controllers, connectors, HTTP commander, NALU parsing) is now **85–100%** covered.

All tests run via:
`xcodebuild test -scheme IRIPCamera-swift -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IRIPCamera-swiftTests`

## Refactors (behaviour-preserving)
- **`IRStreamConnectionRequestFactory`** – replaced the parallel url/enable arrays with a single `(urlKey, enableKey)` table and an injectable `UserDefaults` for testing.
- **`IRStreamControllerFactory`** – dropped the redundant optional + force-unwrap.
- **`HttpRequesting` protocol** – Alamofire-free abstraction (`HttpRequestMethod`) injected into `HttpAPICommander`, so `AddressConnector`'s retry logic can be tested with a mock client.
- **`IRStreamController`** – extracted the playback state switch into a decoupled `PlaybackState` + `handle(playbackState:)` seam, testable without an IRPlayer dependency.
- **`NALUParser`** – extracted all H.264/HEVC parameter-set parsing and Annex B↔AVCC conversion from `IRStreamVideoDecoder` into a dependency-free helper operating on `[UInt8]`/`Data` instead of unsafe pointers and instance side effects.

## Bug fixes (found by the new tests)
- **`IRStreamController.init(device:)`** never set `streamConnector.delegate = self`, so all custom-device streaming results were silently dropped. Now mirrors `init(rtspURL:)`.
- **`IRCustomStreamConnector.didGetRTSPUrlResult`** indexed `streamInfoArray[ch]` with no bounds check, crashing whenever the array was empty. Guarded with `indices.contains(ch)`.
- **`HttpRequest.doJsonHttpRequest`** ignored the `method` parameter entirely; it now applies it to the `URLRequest`.

## Tests added (~60 cases)
Factories, `MultiPort`, `IRStreamConnector`, `DeviceClass` (incl. `NSCopying`), `DelayedTask`, `AddressConnector` retry/escalation, `DeviceConnector` login guard + delegate forwarding, the base `HttpAPICommander` stubs, `IRCustomStreamConnector` delegate reactions, the `IRStreamController` state machine + connector reactions, and full coverage of `NALUParser`.

## Notes
- The unit test target does not link IRPlayer/Alamofire; seams above are deliberately designed so tests need neither.
- Remaining uncovered code is mostly UI view controllers and the VideoToolbox decode path, which need UI/integration tests rather than unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)